### PR TITLE
Feat/navigation bw skillshome chainhome

### DIFF
--- a/components/Chain/ScorecardList.tsx
+++ b/components/Chain/ScorecardList.tsx
@@ -7,8 +7,6 @@ type ScorecardListProps = {
 };
 
 const ScorecardList: FC<ScorecardListProps> = (props) => {
-	console.log(props);
-
 	return (
 		<View>
 			<Text>Scorecard Item List ...</Text>

--- a/components/Chain/ScorecardList.tsx
+++ b/components/Chain/ScorecardList.tsx
@@ -1,14 +1,13 @@
-import React, { useEffect } from "react";
-import { ScrollView, View, Text, FlatList, StyleSheet } from "react-native";
+import React, { FC, useEffect } from "react";
+import { View, Text, FlatList, StyleSheet } from "react-native";
 import { ScorecardListItem } from "./index";
 
-export default function ScorecardList(props) {
-	// let data = null;
+type ScorecardListProps = {
+	data: [];
+};
 
-	// useEffect(() => {
-	// 	data = props.data;
-	// 	console.log(data);
-	// });
+const ScorecardList: FC<ScorecardListProps> = (props) => {
+	console.log(props);
 
 	return (
 		<View>
@@ -22,7 +21,7 @@ export default function ScorecardList(props) {
 			)}
 		</View>
 	);
-}
+};
 
 const styles = StyleSheet.create({
 	container: {
@@ -35,3 +34,5 @@ const styles = StyleSheet.create({
 		fontWeight: "bold",
 	},
 });
+
+export default ScorecardList;

--- a/components/Chain/ScorecardListItem.tsx
+++ b/components/Chain/ScorecardListItem.tsx
@@ -5,7 +5,6 @@ import { useNavigation } from "@react-navigation/native";
 
 export default function ScorecardListItem({ props }) {
 	const { id, skill, mastered } = props.data;
-	console.log(props);
 
 	return (
 		<Card style={styles.container}>

--- a/components/SkillsHome/SkillGrade.tsx
+++ b/components/SkillsHome/SkillGrade.tsx
@@ -3,7 +3,12 @@ import { StyleSheet, View, Text, Image } from "react-native";
 import { Card } from "react-native-paper";
 
 export default function SkillGrade(props) {
-	console.log(props.data);
+	function createSkillTitleString(data: []): string {
+		console.log(data);
+		let t = data.map((e) => e.title);
+		let str = t.join(", ");
+		return str;
+	}
 
 	return (
 		<Card style={styles.container}>
@@ -13,14 +18,8 @@ export default function SkillGrade(props) {
 			/>
 			<View style={styles.subcontainer}>
 				<Text style={styles.skillGrade}>{props.name}</Text>
-				<View style={styles}>
-					{props.data.map((e, i) => {
-						return (
-							<Text key={i.toString()} style={styles.skillTitle}>
-								{e.title}
-							</Text>
-						);
-					})}
+				<View style={styles.skillList}>
+					<Text>{createSkillTitleString(props.data)}</Text>
 				</View>
 			</View>
 		</Card>
@@ -51,6 +50,10 @@ const styles = StyleSheet.create({
 		padding: 5,
 		display: "flex",
 		flexDirection: "column",
+	},
+	skillList: {
+		display: "flex",
+		flexDirection: "row",
 	},
 	skillTitle: {
 		padding: 2,

--- a/components/SkillsHome/SkillGrade.tsx
+++ b/components/SkillsHome/SkillGrade.tsx
@@ -1,21 +1,20 @@
-import React from "react";
+import React, { FC } from "react";
 import { StyleSheet, View, Text, Image } from "react-native";
 import { Card } from "react-native-paper";
-import { RootNavProps as Props } from "../../navigation/root_types";
+import { RootNavProps } from "../../navigation/root_types";
 
-export default function SkillGrade({
-	navigation,
-	route,
-}: Props<"SkillsHomeScreen">) {
-	console.log(navigation);
-	function createSkillTitleString(data: []): string {
-		let t = data.map((e) => e.title);
-		let str = t.join(", ");
-		console.log(str);
+type Props = {
+	data: [];
+	name: string;
+};
 
-		return str;
-	}
+function createSkillTitleString(data: []): string {
+	let t = data.map((e) => e.title);
+	let str = t.join(", ");
+	return str;
+}
 
+const SkillGrade: FC<Props> = (props) => {
 	return (
 		<Card style={styles.container}>
 			<Image
@@ -23,14 +22,14 @@ export default function SkillGrade({
 				style={styles.icon}
 			/>
 			<View style={styles.subcontainer}>
-				{/* <Text style={styles.skillGrade}>{props.name}</Text> */}
+				<Text style={styles.skillGrade}>{props.name}: </Text>
 				<View style={styles.skillList}>
-					{/* <Text>{createSkillTitleString(props.data)}</Text> */}
+					<Text>{createSkillTitleString(props.data)}</Text>
 				</View>
 			</View>
 		</Card>
 	);
-}
+};
 
 const styles = StyleSheet.create({
 	container: {
@@ -68,3 +67,5 @@ const styles = StyleSheet.create({
 		fontWeight: "600",
 	},
 });
+
+export default SkillGrade;

--- a/components/SkillsHome/SkillGrade.tsx
+++ b/components/SkillsHome/SkillGrade.tsx
@@ -1,12 +1,18 @@
 import React from "react";
 import { StyleSheet, View, Text, Image } from "react-native";
 import { Card } from "react-native-paper";
+import { RootNavProps as Props } from "../../navigation/root_types";
 
-export default function SkillGrade(props) {
+export default function SkillGrade({
+	navigation,
+	route,
+}: Props<"SkillsHomeScreen">) {
+	console.log(navigation);
 	function createSkillTitleString(data: []): string {
-		console.log(data);
 		let t = data.map((e) => e.title);
 		let str = t.join(", ");
+		console.log(str);
+
 		return str;
 	}
 
@@ -17,9 +23,9 @@ export default function SkillGrade(props) {
 				style={styles.icon}
 			/>
 			<View style={styles.subcontainer}>
-				<Text style={styles.skillGrade}>{props.name}</Text>
+				{/* <Text style={styles.skillGrade}>{props.name}</Text> */}
 				<View style={styles.skillList}>
-					<Text>{createSkillTitleString(props.data)}</Text>
+					{/* <Text>{createSkillTitleString(props.data)}</Text> */}
 				</View>
 			</View>
 		</Card>

--- a/components/SkillsHome/SkillListCard.tsx
+++ b/components/SkillsHome/SkillListCard.tsx
@@ -1,23 +1,25 @@
 import React, { FC, useEffect, useState } from "react";
 import { StyleSheet, View, Text } from "react-native";
-import { useNavigation } from "@react-navigation/native";
+import { useNavigation, useRoute } from "@react-navigation/native";
 import { Button, Card } from "react-native-paper";
 import { RootNavProps } from "../../navigation/root_types";
 
 import { SkillGrade } from "./index";
 
 type Item = {
-	name: string;
-	subItems: [];
+	item: {
+		name: string;
+		subItems: [];
+	};
 };
 
 type ListCardProps = {
-	dataItem: undefined | Item;
+	dataItem: Item;
 	rootProps: RootNavProps<"SkillsHomeScreen">;
 };
 
 function filterSkillByScore(arr: [], score: number) {
-	let temp = [];
+	let temp: [] = [];
 	arr.forEach((e) => {
 		if (e.score === score) {
 			temp.push(e);
@@ -29,7 +31,6 @@ function filterSkillByScore(arr: [], score: number) {
 const SkillListCard: FC<ListCardProps> = (props) => {
 	const navigation = useNavigation();
 	const { name, subItems } = props.dataItem.item;
-	console.log(props);
 
 	let mastered = filterSkillByScore(subItems, 1);
 	let inProgress = filterSkillByScore(subItems, 0);
@@ -43,8 +44,12 @@ const SkillListCard: FC<ListCardProps> = (props) => {
 				<SkillGrade data={inProgress} name={"In Progress"} />
 				<SkillGrade data={needsSupport} name={"Needs Support"} />
 			</View>
+
 			<Button
 				mode="contained"
+				//
+				// --- Here... send selected skill to Context API
+				//
 				onPress={() => navigation.navigate("ChainsHomeScreen")}
 			>
 				Go To Skill

--- a/components/SkillsHome/SkillListCard.tsx
+++ b/components/SkillsHome/SkillListCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { FC, useEffect, useState } from "react";
 import { StyleSheet, View, Text } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import { Button, Card } from "react-native-paper";
@@ -6,7 +6,17 @@ import { RootNavProps } from "../../navigation/root_types";
 
 import { SkillGrade } from "./index";
 
-function filterSkillByScore(arr, score) {
+type Item = {
+	name: string;
+	subItems: [];
+};
+
+type ListCardProps = {
+	dataItem: undefined | Item;
+	rootProps: RootNavProps<"SkillsHomeScreen">;
+};
+
+function filterSkillByScore(arr: [], score: number) {
 	let temp = [];
 	arr.forEach((e) => {
 		if (e.score === score) {
@@ -16,15 +26,11 @@ function filterSkillByScore(arr, score) {
 	return temp;
 }
 
-export default function SkillListCard({
-	navigation,
-	route,
-	dataItem,
-}: RootNavProps<"SkillsHomeScreen">) {
-	// console.log("skill list card");
-	// console.log(dataItem.item);
+const SkillListCard: FC<ListCardProps> = (props) => {
+	const navigation = useNavigation();
+	const { name, subItems } = props.dataItem.item;
+	console.log(props);
 
-	const { name, subItems } = dataItem.item;
 	let mastered = filterSkillByScore(subItems, 1);
 	let inProgress = filterSkillByScore(subItems, 0);
 	let needsSupport = filterSkillByScore(subItems, 2);
@@ -45,7 +51,7 @@ export default function SkillListCard({
 			</Button>
 		</Card>
 	);
-}
+};
 
 const styles = StyleSheet.create({
 	container: {
@@ -85,3 +91,5 @@ const styles = StyleSheet.create({
 	// 	borderRadius: 5,
 	// },
 });
+
+export default SkillListCard;

--- a/components/SkillsHome/SkillListCard.tsx
+++ b/components/SkillsHome/SkillListCard.tsx
@@ -45,11 +45,6 @@ const SkillListCard: FC<ListCardProps> = (props) => {
 		//
 		// --- Here... send selected skill to Context API
 		//
-		console.log("Setting context");
-		console.log("Setting context");
-		console.log("Setting context");
-		console.log("Setting context");
-
 		navigation.navigate("ChainsHomeScreen");
 	}
 

--- a/components/SkillsHome/SkillListCard.tsx
+++ b/components/SkillsHome/SkillListCard.tsx
@@ -3,6 +3,10 @@ import { StyleSheet, View, Text } from "react-native";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { Button, Card } from "react-native-paper";
 import { RootNavProps } from "../../navigation/root_types";
+import {
+	ChainStack,
+	ChainNavigator,
+} from "../../navigation/ChainNavigation/ChainNavStack";
 
 import { SkillGrade } from "./index";
 
@@ -15,7 +19,7 @@ type Item = {
 
 type ListCardProps = {
 	dataItem: Item;
-	rootProps: RootNavProps<"SkillsHomeScreen">;
+	root: RootNavProps<"SkillsHomeScreen">;
 };
 
 function filterSkillByScore(arr: [], score: number) {
@@ -30,11 +34,24 @@ function filterSkillByScore(arr: [], score: number) {
 
 const SkillListCard: FC<ListCardProps> = (props) => {
 	const navigation = useNavigation();
+
 	const { name, subItems } = props.dataItem.item;
 
 	let mastered = filterSkillByScore(subItems, 1);
 	let inProgress = filterSkillByScore(subItems, 0);
 	let needsSupport = filterSkillByScore(subItems, 2);
+
+	function SetContextSkill() {
+		//
+		// --- Here... send selected skill to Context API
+		//
+		console.log("Setting context");
+		console.log("Setting context");
+		console.log("Setting context");
+		console.log("Setting context");
+
+		navigation.navigate("ChainsHomeScreen");
+	}
 
 	return (
 		<Card style={styles.container}>
@@ -45,14 +62,8 @@ const SkillListCard: FC<ListCardProps> = (props) => {
 				<SkillGrade data={needsSupport} name={"Needs Support"} />
 			</View>
 
-			<Button
-				mode="contained"
-				//
-				// --- Here... send selected skill to Context API
-				//
-				onPress={() => navigation.navigate("ChainsHomeScreen")}
-			>
-				Go To Skill
+			<Button mode="contained" onPress={() => SetContextSkill()}>
+				Go to Skill
 			</Button>
 		</Card>
 	);

--- a/components/SkillsHome/SkillsList.tsx
+++ b/components/SkillsHome/SkillsList.tsx
@@ -7,8 +7,6 @@ type SkillsListProps = {
 };
 
 const SkillsList: FC<SkillsListProps> = (props) => {
-	console.log(props.data);
-
 	return (
 		<View>
 			<View style={styles.container}>

--- a/components/SkillsHome/SkillsList.tsx
+++ b/components/SkillsHome/SkillsList.tsx
@@ -1,9 +1,11 @@
 import React, { FC } from "react";
 import { StyleSheet, FlatList, View, Text } from "react-native";
 import { SkillListCard } from "./index";
+import { RootNavProps } from "../../navigation/root_types";
 
 type SkillsListProps = {
 	data?: [];
+	root: RootNavProps<"SkillsHomeScreen">;
 };
 
 const SkillsList: FC<SkillsListProps> = (props) => {
@@ -18,7 +20,9 @@ const SkillsList: FC<SkillsListProps> = (props) => {
 					}}
 					data={props.data}
 					keyExtractor={(index) => index}
-					renderItem={(item) => <SkillListCard dataItem={item} />}
+					renderItem={(item) => (
+						<SkillListCard dataItem={item} root={props.root} />
+					)}
 				/>
 			</View>
 		</View>

--- a/components/SkillsHome/SkillsList.tsx
+++ b/components/SkillsHome/SkillsList.tsx
@@ -4,15 +4,19 @@ import { SkillListCard } from "./index";
 import { RootNavProps as Props } from "../../navigation/root_types";
 
 export default function SkillsList({
-	data,
 	navigation,
 	route,
+	data,
 }: Props<"SkillsHomeScreen">) {
 	return (
 		<View>
 			<View style={styles.container}>
 				<Text style={styles.title}>SKILLS LIST</Text>
 				<FlatList
+					contentContainerStyle={{
+						flexGrow: 1,
+						justifyContent: "center",
+					}}
 					data={data}
 					keyExtractor={(index) => index.toString()}
 					renderItem={(item) => <SkillListCard dataItem={item} />}

--- a/components/SkillsHome/SkillsList.tsx
+++ b/components/SkillsHome/SkillsList.tsx
@@ -1,13 +1,14 @@
-import React from "react";
+import React, { FC } from "react";
 import { StyleSheet, FlatList, View, Text } from "react-native";
 import { SkillListCard } from "./index";
-import { RootNavProps as Props } from "../../navigation/root_types";
 
-export default function SkillsList({
-	navigation,
-	route,
-	data,
-}: Props<"SkillsHomeScreen">) {
+type SkillsListProps = {
+	data?: [];
+};
+
+const SkillsList: FC<SkillsListProps> = (props) => {
+	console.log(props.data);
+
 	return (
 		<View>
 			<View style={styles.container}>
@@ -17,14 +18,14 @@ export default function SkillsList({
 						flexGrow: 1,
 						justifyContent: "center",
 					}}
-					data={data}
-					keyExtractor={(index) => index.toString()}
+					data={props.data}
+					keyExtractor={(index) => index}
 					renderItem={(item) => <SkillListCard dataItem={item} />}
 				/>
 			</View>
 		</View>
 	);
-}
+};
 
 const styles = StyleSheet.create({
 	container: {
@@ -41,3 +42,5 @@ const styles = StyleSheet.create({
 		color: "#b72ef2",
 	},
 });
+
+export default SkillsList;

--- a/navigation/ChainNavigation/ChainNavStack.tsx
+++ b/navigation/ChainNavigation/ChainNavStack.tsx
@@ -8,7 +8,7 @@ import {
 	StepScreen,
 } from "../../screens/index";
 
-const ChainStack = createStackNavigator<ChainStackParamList>();
+export const ChainStack = createStackNavigator<ChainStackParamList>();
 
 export function ChainNavigator() {
 	return (

--- a/navigation/ChainNavigation/ChainNavStack.tsx
+++ b/navigation/ChainNavigation/ChainNavStack.tsx
@@ -13,7 +13,7 @@ const ChainStack = createStackNavigator<ChainStackParamList>();
 export function ChainNavigator() {
 	return (
 		<ChainStack.Navigator
-			initialRouteName="ChainHomeScreen"
+			initialRouteName="ChainsHomeScreen"
 			screenOptions={{ headerShown: false }}
 		>
 			<ChainStack.Screen

--- a/navigation/ChainNavigation/ChainNavStack.tsx
+++ b/navigation/ChainNavigation/ChainNavStack.tsx
@@ -14,7 +14,7 @@ export function ChainNavigator() {
 	return (
 		<ChainStack.Navigator
 			initialRouteName="ChainHomeScreen"
-			screenOptions={{ headerShown: true }}
+			screenOptions={{ headerShown: false }}
 		>
 			<ChainStack.Screen
 				name="ChainsHomeScreen"

--- a/navigation/ChainNavigation/types.ts
+++ b/navigation/ChainNavigation/types.ts
@@ -2,7 +2,7 @@ import { StackNavigationProp } from "@react-navigation/stack";
 import { RouteProp } from "@react-navigation/native";
 
 export type ChainStackParamList = {
-	ChainHomeScreen: { thisSkill: string };
+	ChainsHomeScreen: { skill: string };
 	BaseAssessScreen: undefined;
 	PrepareMaterialsScreen: undefined;
 	RewardScreen: undefined;

--- a/navigation/ChainNavigation/types.ts
+++ b/navigation/ChainNavigation/types.ts
@@ -2,13 +2,13 @@ import { StackNavigationProp } from "@react-navigation/stack";
 import { RouteProp } from "@react-navigation/native";
 
 export type ChainStackParamList = {
-    ChainHomeScreen: {thisSkill: string};
-    BaseAssessScreen: undefined;
-    PrepareMaterialsScreen: undefined;
-    RewardScreen: undefined;
-    StepScreen: undefined;
-    TipsTricksScreen: undefined;
-}
+	ChainHomeScreen: { thisSkill: string };
+	BaseAssessScreen: undefined;
+	PrepareMaterialsScreen: undefined;
+	RewardScreen: undefined;
+	StepScreen: undefined;
+	TipsTricksScreen: undefined;
+};
 
 export type ChainNavProps<T extends keyof ChainStackParamList> = {
 	navigation: StackNavigationProp<ChainStackParamList, T>;

--- a/navigation/ChainNavigation/types.ts
+++ b/navigation/ChainNavigation/types.ts
@@ -2,7 +2,7 @@ import { StackNavigationProp } from "@react-navigation/stack";
 import { RouteProp } from "@react-navigation/native";
 
 export type ChainStackParamList = {
-	ChainsHomeScreen: { skill: string };
+	ChainsHomeScreen: undefined;
 	BaseAssessScreen: undefined;
 	PrepareMaterialsScreen: undefined;
 	RewardScreen: undefined;

--- a/navigation/index.tsx
+++ b/navigation/index.tsx
@@ -33,7 +33,7 @@ const Stack = createStackNavigator<RootStackParamList>();
 function RootNavigator() {
 	return (
 		<Stack.Navigator
-			initialRouteName="SkillsHomeScreen"
+			initialRouteName="LandingScreen"
 			screenOptions={{ headerShown: true }}
 		>
 			<Stack.Screen

--- a/navigation/index.tsx
+++ b/navigation/index.tsx
@@ -41,7 +41,10 @@ function RootNavigator() {
 				component={SkillsHomeScreen}
 			/>
 			<Stack.Screen name="LandingScreen" component={LandingScreen} />
-			<Stack.Screen name="ChainsHomeScreen" component={ChainNavigator} />
+			<Stack.Screen
+				name="ChainsHomeScreen"
+				component={ChainsHomeScreen}
+			/>
 		</Stack.Navigator>
 	);
 }

--- a/navigation/root_types.ts
+++ b/navigation/root_types.ts
@@ -4,7 +4,7 @@ import { RouteProp } from "@react-navigation/native";
 export type RootStackParamList = {
 	LandingScreen: undefined;
 	SkillsHomeScreen: undefined;
-	ChainsHomeScreen: { skill: string };
+	ChainsHomeScreen: undefined;
 };
 
 // A generic used to provide propTypes to Root Screens.

--- a/navigation/root_types.ts
+++ b/navigation/root_types.ts
@@ -10,7 +10,7 @@ type dataItem = [
 
 export type RootStackParamList = {
 	LandingScreen: undefined;
-	SkillsHomeScreen: undefined | { data: data; dataItem: dataItem };
+	SkillsHomeScreen: { data: data; dataItem: dataItem };
 	ChainsHomeScreen: undefined | { thisSkill: string; dataItem: dataItem };
 };
 

--- a/navigation/root_types.ts
+++ b/navigation/root_types.ts
@@ -1,17 +1,10 @@
 import { StackNavigationProp } from "@react-navigation/stack";
 import { RouteProp } from "@react-navigation/native";
 
-type data = [
-	{ name: string; subItems: [{ id: string; title: string; score: Number }] }
-];
-type dataItem = [
-	{ name: string; subItems: [{ id: string; title: string; score: Number }] }
-];
-
 export type RootStackParamList = {
 	LandingScreen: undefined;
-	SkillsHomeScreen: { data: data; dataItem: dataItem };
-	ChainsHomeScreen: undefined | { thisSkill: string; dataItem: dataItem };
+	SkillsHomeScreen: undefined;
+	ChainsHomeScreen: { skill: string };
 };
 
 // A generic used to provide propTypes to Root Screens.

--- a/navigation/root_types.ts
+++ b/navigation/root_types.ts
@@ -11,7 +11,7 @@ type dataItem = [
 export type RootStackParamList = {
 	LandingScreen: undefined;
 	SkillsHomeScreen: undefined | { data: data; dataItem: dataItem };
-	ChainsHomeScreen: undefined | { thisSkill: string; data: [] };
+	ChainsHomeScreen: undefined | { thisSkill: string; dataItem: dataItem };
 };
 
 // A generic used to provide propTypes to Root Screens.

--- a/screens/ChainsHomeScreen.tsx
+++ b/screens/ChainsHomeScreen.tsx
@@ -1,11 +1,13 @@
 import React, { FC, useEffect, useState } from "react";
 import { View, Text, StyleSheet } from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import { RouteProp } from "@react-navigation/native";
 import { ChainNavProps } from "../navigation/ChainNavigation/types";
 import { ScorecardList } from "../components/Chain/index";
 
 type Props = {
-	skill?: string;
-	rootProps: ChainNavProps<"ChainsHomeScreen">;
+	skill?: {};
+	route: ChainNavProps<"ChainsHomeScreen">;
 };
 
 const ChainsHomeScreen: FC<Props> = (props) => {

--- a/screens/ChainsHomeScreen.tsx
+++ b/screens/ChainsHomeScreen.tsx
@@ -1,18 +1,15 @@
-import React, { useEffect, useState } from "react";
+import React, { FC, useEffect, useState } from "react";
 import { View, Text, StyleSheet } from "react-native";
-import { RootNavProps } from "../navigation/root_types";
+import { ChainNavProps } from "../navigation/ChainNavigation/types";
 import { ScorecardList } from "../components/Chain/index";
 
-export default function ChainsHomeScreen({
-	navigation,
-	route,
-}: RootNavProps<"ChainsHomeScreen">) {
-	// const { thisSkill } = route.params;
-	// const [data, setData] = useState();
+type Props = {
+	skill?: string;
+	rootProps: ChainNavProps<"ChainsHomeScreen">;
+};
 
-	// useEffect(() => {
-	// 	navigation.setOptions({ title: skill });
-	// });
+const ChainsHomeScreen: FC<Props> = (props) => {
+	console.log(props);
 
 	return (
 		<View style={styles.container}>
@@ -22,7 +19,7 @@ export default function ChainsHomeScreen({
 			<ScorecardList data={data} /> */}
 		</View>
 	);
-}
+};
 
 const styles = StyleSheet.create({
 	container: {
@@ -40,3 +37,5 @@ const styles = StyleSheet.create({
 		width: "80%",
 	},
 });
+
+export default ChainsHomeScreen;

--- a/screens/ChainsHomeScreen.tsx
+++ b/screens/ChainsHomeScreen.tsx
@@ -1,7 +1,5 @@
 import React, { FC, useEffect, useState } from "react";
 import { View, Text, StyleSheet } from "react-native";
-import { useNavigation } from "@react-navigation/native";
-import { RouteProp } from "@react-navigation/native";
 import { ChainNavProps } from "../navigation/ChainNavigation/types";
 import { ScorecardList } from "../components/Chain/index";
 
@@ -11,8 +9,6 @@ type Props = {
 };
 
 const ChainsHomeScreen: FC<Props> = (props) => {
-	console.log(props);
-
 	return (
 		<View style={styles.container}>
 			<Text>CHAINS HOME</Text>


### PR DESCRIPTION
Having made changes in my prior PR and gained further understanding of Typescript vis-a-vis React-Navigation, I needed to refactor the navigation b/w SkillsHomeScreen (via its components) and ChainsHomeScreen.

There were edits all over.  But, the takeaway is that:
* the ChainsHomeScreen component, in the RootStackNav, was replaced with the "ChainsStackNav".  Thus given the CHAINS functionality of the app its own, nested navigation stack.
* I've implemented (hopefully) proper Typescript/React-Nav.
* Cleaned up
* Added Prop types to a few components.


Note:
1.  I've begun using `React.FC` w/ Typescript.  This means that previous functional components have been refactored from 
`export default function SomeFunction()` to `const SomeFunction: FC<SomePropType> = (props) => { ... }`.  *And* I still need to make this change uniform throughout the codebase.
2. In conjunction with the above, components and screens also need uniform implementation of Prop type declaration.

Hopefully, this all made some degree of sense.  I'm fried.