### PR TITLE
Fixes chain mastery prompt level logic for probe sessions

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,7 +17,7 @@
         },
         "assetBundlePatterns": ["**/*"],
         "ios": {
-            "buildNumber": "7",
+            "buildNumber": "8",
             "supportsTablet": true,
             "bundleIdentifier": "SkillSTAR",
             "infoPlist": {


### PR DESCRIPTION
**Initial probes (i.e., before any training sessions):**
- 3 consecutive probe successes on a step should set that step to mastered.
- Fewer than 3 probe successes on a step should set that step to `not_yet_started` (or focus for the first unmastered step).

**After initial probes:**
- 3 consecutive probe failures on a `not_yet_started` or `focus` step should have ***no effect on target prompt level***.

**After mastery:**
- 3 consecutive probe failures on a `mastered` or `booster_mastered` step should set the step status to booster_needed with shadow target prompt level.
- 3 consecutive probe failures on a `booster_needed` step should have ***no effect on target prompt level***.